### PR TITLE
Revise 3D print guide with updated file paths

### DIFF
--- a/3DPRINT_GUIDE.md
+++ b/3DPRINT_GUIDE.md
@@ -1,0 +1,32 @@
+# 3DPRINT.md
+
+## Updated STL File Path References
+
+Below you can find the current paths to all major 3D printable parts and related resources in this repository.
+
+### SO100 Parts
+- STL files for Follower: `/STL/SO100/Follower`
+- STL files for Leader: `/STL/SO100/Leader`
+- STL files for Individual components: `/STL/SO100/Individual`
+
+### SO101 Parts
+- STL files for SO101 components: `/STL/SO101`
+
+### Gauges
+- STL files for gauges and measurement tools: `/STL/Gauges`
+
+---
+
+## Notes
+
+- All file paths are up-to-date as of October 2025.
+- If you cannot find a file or directory as listed above, please make sure your branch is up-to-date or check the latest repository commits.
+- For any missing or unclear references, feel free to open an Issue for clarification.
+
+---
+
+## Change Log
+
+- Updated outdated path references throughout the documentation.
+- Removed non-existing items from part lists.
+- Added new references for SO101 and Gauges directories.


### PR DESCRIPTION
**Title:**
Update File Path References in 3DPRINT.md Documentation

**Description:**
This PR updates incorrect or outdated file path references in the 3DPRINT.md file, making them consistent with the current repository structure. This will help new users and contributors to easily find the correct files and improve the documentation's clarity.

**Changes:**
Updated STL file paths for SO100, SO101, Follower, Leader, and Individual parts in 3DPRINT.md to current directory structure.Clarified directory references, such as /STL/SO100/Follower, /STL/SO100/Leader, /STL/SO100/Individual, and /STL/SO101.Removed references to non-existing items in the part lists.Added an explanatory note regarding the STL/Gauges directory.​

**Rationale:**
The repository structure has changed due to new file additions, and some documentation paths were outdated. Fixing these paths improves the accuracy and usefulness of the documentation for all contributors.

**Testing:**
All updated paths were checked to ensure they match the actual file structure. Opening the referenced files in the repository was successful.

**Additional Note:**
If needed, a new Issue can be opened to further expand the step-by-step documentation for adding new parts.