### PR TITLE
Update SO101 actuator model params for Mujoco and successful sim-to-real transfer of RL policies

### DIFF
--- a/Simulation/SO101/so101_new_calib.xml
+++ b/Simulation/SO101/so101_new_calib.xml
@@ -20,8 +20,11 @@
     <default class="sts3215">
       <geom contype="0" conaffinity="0"/>
       <joint damping="0.60" frictionloss="0.052" armature="0.028"/>
-      <!-- For lerobot this are not exactly the motor params as the Kp and Kd not map 1-to-1 thus motor idendification with lerobot Kp=16 and Kd=32 should actually be done -->
-      <position kp="17.8"/>
+      <!-- These gains are not a 1-to-1 mapping of the servo gains used in
+           Lerobot. These position gains and forces were calculated according to
+           https://github.com/Gregory119/RBE501-RL-arm-project/blob/main/gymnasium_env/README.md,
+           assuming that the servo proportional gain is set to 16. -->
+      <position kp="998.22" kv="2.731" forcerange="-2.94 2.94"/>
     </default>
     <default class="backlash">
       <!-- +/- 0.5° of backlash -->


### PR DESCRIPTION
I ran into problems with sim-to-real transfer of a [reinforcement learning policy I trained for the SO101 arm in Mujoco](https://github.com/Gregory119/RBE501-RL-arm-project/tree/main). I found that the parameters used in the `<position>` element are incorrect. I updated these using a script I wrote based on equations derived from a DC motor (see [details here](https://github.com/Gregory119/RBE501-RL-arm-project/blob/main/gymnasium_env/README.md)), which I successfully used for sim-to-real transfer.